### PR TITLE
doc: Remove `clang-format` from pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
         fix
 -   [ ] If your PR adds a feature or fix it also needs to add or modify at least
         one test
--   [ ] All code in your PR needs to have been formatted by `clang-format`
+-   [ ] All code in your PR needs to have been formatted.
 -   [ ] The merge commit title should follow our commit prefix convention of
         either "feat", "fix", "doc", or "refactor"
 -   [ ] The merge commit body should reference at least one issue

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
         fix
 -   [ ] If your PR adds a feature or fix it also needs to add or modify at least
         one test
--   [ ] All code in your PR needs to have been formatted.
+-   [ ] All code in your PR needs to have been formatted
 -   [ ] The merge commit title should follow our commit prefix convention of
         either "feat", "fix", "doc", or "refactor"
 -   [ ] The merge commit body should reference at least one issue


### PR DESCRIPTION
## Describe your changes

Fixes #24.

- Removes `clang-format` from pr-template formatting checkbox

## Checklist before requesting review

-   [x] Feature/fix PRs should add one atomic (as small as possible) feature or
        fix
-   [x] If your PR adds a feature or fix it also needs to add or modify at least
        one test
-   [x] All code in your PR needs to have been formatted
-   [x] The merge commit title should follow our commit prefix convention of
        either "feat", "fix", "doc", or "refactor"
-   [x] The merge commit body should reference at least one issue
-   [x] The code compiles and all the tests pass
