### PR TITLE
chore: add default gradle github builtin CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,34 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+    - name: Build with Gradle
+      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+      with:
+        arguments: build


### PR DESCRIPTION
solves #13

This is the default workflow file for the java gradle github CI

## Checklist before requesting review

-   [x] Feature/fix PRs should add one atomic (as small as possible) feature or
        fix
-   [x] If your PR adds a feature or fix it also needs to add or modify at least
        one test
-   [x] All code in your PR needs to have been formatted
-   [x] The merge commit title should follow our commit prefix convention of
        either "feat", "fix", "doc", or "refactor"
-   [x] The merge commit body should reference at least one issue
-   [x] The code compiles and all the tests pass
