### PR TITLE
feat: Add the ability to send HTTP requests

### DIFF
--- a/app/src/main/java/ciserver/ContinuousIntegrationServer.java
+++ b/app/src/main/java/ciserver/ContinuousIntegrationServer.java
@@ -26,6 +26,24 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         // For example:
         // 1st clone your repository
         // 2nd compile the code
+
+        // Build the response according to the pipeline's return status (dummy variables
+        // used here as we have no "real" requests to start the pipeline with yet).
+        String[] repo_details = event.repository.full_name.split("/");
+        PipelineUpdateRequest pr = new PipelineUpdateRequest(repo_details[0], repo_details[1], event.headCommit.id, "token",
+                CommitStatus.SUCCESS, "", "Test passed!", "ci", null);
+
+        try {
+            int res = pr.send();
+
+            if (res != 201) {
+                System.err.println("HTTP POST error: " + res);
+            }
+        } catch (Exception e) {
+            System.err.println(e);
+        }
+
+        System.out.println("Commit status update sent successfully.");
     }
 
     public void handle(String target,

--- a/app/src/main/java/ciserver/ContinuousIntegrationServer.java
+++ b/app/src/main/java/ciserver/ContinuousIntegrationServer.java
@@ -5,6 +5,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.ServletException;
 
 import java.io.IOException;
+import java.net.http.HttpResponse;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -35,9 +36,9 @@ public class ContinuousIntegrationServer extends AbstractHandler {
                 GH_ACCESS_TOKEN, CommitStatus.SUCCESS, "", "Test passed!", "ci", null);
 
         try {
-            int res = pr.send();
+            HttpResponse<String> res = pr.send();
 
-            if (res != 201) {
+            if (res.statusCode() != 201) {
                 System.err.println("HTTP POST error: " + res);
             }
         } catch (Exception e) {

--- a/app/src/main/java/ciserver/ContinuousIntegrationServer.java
+++ b/app/src/main/java/ciserver/ContinuousIntegrationServer.java
@@ -18,8 +18,8 @@ import com.google.gson.JsonSyntaxException;
 
 public class ContinuousIntegrationServer extends AbstractHandler {
 
-    Gson gson = new Gson();
-    final String GH_ACCESS_TOKEN = System.getenv("GH_ACCESS_TOKEN");
+    private final Gson gson = new Gson();
+    private final String GH_ACCESS_TOKEN = System.getenv("GH_ACCESS_TOKEN");
 
     private void handlePushEvent(PushEvent event) {
         System.err.printf("%s, %s", event.ref, event.headCommit.url);

--- a/app/src/main/java/ciserver/ContinuousIntegrationServer.java
+++ b/app/src/main/java/ciserver/ContinuousIntegrationServer.java
@@ -18,6 +18,7 @@ import com.google.gson.JsonSyntaxException;
 public class ContinuousIntegrationServer extends AbstractHandler {
 
     Gson gson = new Gson();
+    final String GH_ACCESS_TOKEN = System.getenv("GH_ACCESS_TOKEN");
 
     private void handlePushEvent(PushEvent event) {
         System.err.printf("%s, %s", event.ref, event.headCommit.url);
@@ -30,8 +31,8 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         // Build the response according to the pipeline's return status (dummy variables
         // used here as we have no "real" requests to start the pipeline with yet).
         String[] repo_details = event.repository.full_name.split("/");
-        PipelineUpdateRequest pr = new PipelineUpdateRequest(repo_details[0], repo_details[1], event.headCommit.id, "token",
-                CommitStatus.SUCCESS, "", "Test passed!", "ci", null);
+        PipelineUpdateRequest pr = new PipelineUpdateRequest(repo_details[0], repo_details[1], event.headCommit.id,
+                GH_ACCESS_TOKEN, CommitStatus.SUCCESS, "", "Test passed!", "ci", null);
 
         try {
             int res = pr.send();

--- a/app/src/main/java/ciserver/ContinuousIntegrationServer.java
+++ b/app/src/main/java/ciserver/ContinuousIntegrationServer.java
@@ -32,8 +32,10 @@ public class ContinuousIntegrationServer extends AbstractHandler {
         // Build the response according to the pipeline's return status (dummy variables
         // used here as we have no "real" requests to start the pipeline with yet).
         String[] repo_details = event.repository.full_name.split("/");
-        PipelineUpdateRequest pr = new PipelineUpdateRequest(repo_details[0], repo_details[1], event.headCommit.id,
-                GH_ACCESS_TOKEN, CommitStatus.SUCCESS, "", "Test passed!", "ci", null);
+        var dto = new PipelineUpdateRequestDTO(repo_details[0], repo_details[1], event.headCommit.id, GH_ACCESS_TOKEN,
+                CommitStatus.SUCCESS, "", "Test passed!", "ci", null);
+
+        PipelineUpdateRequest pr = new PipelineUpdateRequest(dto);
 
         try {
             HttpResponse<String> res = pr.send();

--- a/app/src/main/java/ciserver/PipelineUpdateRequest.java
+++ b/app/src/main/java/ciserver/PipelineUpdateRequest.java
@@ -97,9 +97,9 @@ public class PipelineUpdateRequest {
      * PipelineUpdateRequest path,
      * containing information about the success status of a certain build.
      *
-     * @return the HTTP status code of the response.
+     * @return the HTTP response formatted as a String.
      **/
-    public int send() throws InterruptedException, IOException {
+    public HttpResponse<String> send() throws InterruptedException, IOException {
         Gson gson = new Gson();
         String request_body = gson.toJson(this.body);
 
@@ -117,6 +117,6 @@ public class PipelineUpdateRequest {
         // May throw InterruptedException or IOException.
         // Note that it does NOT throw on bad status codes, only internal errors.
         HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
-        return resp.statusCode();
+        return resp;
     }
 }

--- a/app/src/main/java/ciserver/PipelineUpdateRequest.java
+++ b/app/src/main/java/ciserver/PipelineUpdateRequest.java
@@ -53,6 +53,48 @@ class RequestBody {
     }
 }
 
+class PipelineUpdateRequestDTO {
+
+    String owner;
+    String repo;
+    String sha;
+    String token;
+    CommitStatus state;
+    String url;
+    String desc;
+    String ctx;
+    PipelineStage failedOn;
+
+    /**
+     * Creates a new PipelineUpdateRequest object.
+     *
+     * @param owner    The owner of the repository containing the relevant commit.
+     * @param repo     The name of the repository containing the relevant commit.
+     * @param sha      The SHA (hash) of the relevant commit.
+     * @param token    An API authentication token used by the CI server to access
+     *                 the repository and set the commit status.
+     * @param state    The state to set the commit status to.
+     * @param url      A link to view build logs and other output from the server.
+     * @param desc     A short description of the state.
+     * @param ctx      A (case insensitive) label used to differentiate this state
+     *                 from a state set by another system.
+     * @param failedOn The stage where the Pipeline failed, or null if it succeeded.
+     **/
+    PipelineUpdateRequestDTO(String owner, String repo, String sha,
+            String token, CommitStatus state, String url,
+            String desc, String ctx, PipelineStage failedOn) {
+        this.owner = owner;
+        this.repo = repo;
+        this.sha = sha;
+        this.token = token;
+        this.state = state;
+        this.url = url;
+        this.desc = desc;
+        this.ctx = ctx;
+        this.failedOn = failedOn;
+    }
+}
+
 /**
  * A PipelineUpdateRequest is a class used to update the status of a commit on
  * GitHub.
@@ -71,25 +113,14 @@ public class PipelineUpdateRequest {
     /**
      * Creates a new PipelineUpdateRequest object.
      *
-     * @param owner    The owner of the repository containing the relevant commit.
-     * @param repo     The name of the repository containing the relevant commit.
-     * @param sha      The SHA (hash) of the relevant commit.
-     * @param token    An API authentication token used by the CI server to access
-     *                 the repository and set the commit status.
-     * @param state    The state to set the commit status to.
-     * @param url      A link to view build logs and other output from the server.
-     * @param desc     A short description of the state.
-     * @param ctx      A (case insensitive) label used to differentiate this state
-     *                 from a state set by another system.
-     * @param failedOn The stage where the Pipeline failed, or null if it succeeded.
+     * @param DTO An object containing all relevant data.
      **/
-    PipelineUpdateRequest(String owner, String repo, String sha, String token, CommitStatus state, String url,
-            String desc, String ctx, PipelineStage failedOn) {
-        this.path = new RequestPath(owner, repo, sha);
-        String state_str = state.toString().toLowerCase();
-        this.body = new RequestBody(state_str, url, desc, ctx);
-        this.failedOn = Optional.ofNullable(failedOn);
-        this.auth_tkn = token;
+    PipelineUpdateRequest(PipelineUpdateRequestDTO dto) {
+        this.path = new RequestPath(dto.owner, dto.repo, dto.sha);
+        String state_str = dto.state.toString().toLowerCase();
+        this.body = new RequestBody(state_str, dto.url, dto.desc, dto.ctx);
+        this.failedOn = Optional.ofNullable(dto.failedOn);
+        this.auth_tkn = dto.token;
     }
 
     /**

--- a/app/src/main/java/ciserver/PipelineUpdateRequest.java
+++ b/app/src/main/java/ciserver/PipelineUpdateRequest.java
@@ -78,7 +78,7 @@ public class PipelineUpdateRequest {
                         + "/statuses/" + this.path.sha))
                 .POST(HttpRequest.BodyPublishers.ofString(request_body))
                 .header("Accept", "application/vnd.github+json")
-                .header("Authorization", "Bearer: " + this.auth_tkn)
+                .header("Authorization", "Bearer " + this.auth_tkn)
                 .header("X-GitHub-Api-Version", API_VERSION)
                 .build();
 

--- a/app/src/main/java/ciserver/PipelineUpdateRequest.java
+++ b/app/src/main/java/ciserver/PipelineUpdateRequest.java
@@ -21,7 +21,9 @@ enum PipelineStage {
     COMPILE
 }
 
-// Path parameters
+/**
+ * The RequestPath contains the path parameters of the PipelineUpdateRequest.
+ **/
 class RequestPath {
     String owner;
     String repository;
@@ -34,8 +36,9 @@ class RequestPath {
     }
 }
 
-// Body parameters. If this class is needed for another
-// type of post request later on, we could add more.
+/**
+ * The RequestBody contains the body parameters of the PipelineUpdateRequest.
+ **/
 class RequestBody {
     String state;
     String target_url;
@@ -50,6 +53,13 @@ class RequestBody {
     }
 }
 
+/**
+ * A PipelineUpdateRequest is a class used to update the status of a commit on
+ * GitHub.
+ * It is indended to be built using the results of a CI Pipeline execution.
+ *
+ * Currently, the GitHub API version used is hard-coded to 2022-11-28.
+ **/
 public class PipelineUpdateRequest {
     static final String API_VERSION = "2022-11-28";
 
@@ -58,6 +68,21 @@ public class PipelineUpdateRequest {
     Optional<PipelineStage> failedOn;
     String auth_tkn;
 
+    /**
+     * Creates a new PipelineUpdateRequest object.
+     *
+     * @param owner    The owner of the repository containing the relevant commit.
+     * @param repo     The name of the repository containing the relevant commit.
+     * @param sha      The SHA (hash) of the relevant commit.
+     * @param token    An API authentication token used by the CI server to access
+     *                 the repository and set the commit status.
+     * @param state    The state to set the commit status to.
+     * @param url      A link to view build logs and other output from the server.
+     * @param desc     A short description of the state.
+     * @param ctx      A (case insensitive) label used to differentiate this state
+     *                 from a state set by another system.
+     * @param failedOn The stage where the Pipeline failed, or null if it succeeded.
+     **/
     PipelineUpdateRequest(String owner, String repo, String sha, String token, CommitStatus state, String url,
             String desc, String ctx, PipelineStage failedOn) {
         this.path = new RequestPath(owner, repo, sha);
@@ -67,6 +92,13 @@ public class PipelineUpdateRequest {
         this.auth_tkn = token;
     }
 
+    /**
+     * Sends an HTTP POST request to the repository specified in the
+     * PipelineUpdateRequest path,
+     * containing information about the success status of a certain build.
+     *
+     * @return the HTTP status code of the response.
+     **/
     public int send() throws InterruptedException, IOException {
         Gson gson = new Gson();
         String request_body = gson.toJson(this.body);

--- a/app/src/main/java/ciserver/PipelineUpdateRequest.java
+++ b/app/src/main/java/ciserver/PipelineUpdateRequest.java
@@ -1,6 +1,12 @@
 package ciserver;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.Optional;
+import com.google.gson.Gson;
 
 enum CommitStatus {
     ERROR,
@@ -45,15 +51,40 @@ class RequestBody {
 }
 
 public class PipelineUpdateRequest {
+    static final String API_VERSION = "2022-11-28";
+
     RequestPath path;
     RequestBody body;
     Optional<PipelineStage> failedOn;
+    String auth_tkn;
 
-    PipelineUpdateRequest(String owner, String repo, String sha, CommitStatus state, String url, String desc,
-            String ctx, PipelineStage failedOn) {
+    PipelineUpdateRequest(String owner, String repo, String sha, String token, CommitStatus state, String url,
+            String desc, String ctx, PipelineStage failedOn) {
         this.path = new RequestPath(owner, repo, sha);
         String state_str = state.toString().toLowerCase();
         this.body = new RequestBody(state_str, url, desc, ctx);
         this.failedOn = Optional.ofNullable(failedOn);
+        this.auth_tkn = token;
+    }
+
+    public int send() throws InterruptedException, IOException {
+        Gson gson = new Gson();
+        String request_body = gson.toJson(this.body);
+
+        // Build the actual request
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create("https://api.github.com/repos/" + this.path.owner + "/" + this.path.repository
+                        + "/statuses/" + this.path.sha))
+                .POST(HttpRequest.BodyPublishers.ofString(request_body))
+                .header("Accept", "application/vnd.github+json")
+                .header("Authorization", "Bearer: " + this.auth_tkn)
+                .header("X-GitHub-Api-Version", API_VERSION)
+                .build();
+
+        // May throw InterruptedException or IOException.
+        // Note that it does NOT throw on bad status codes, only internal errors.
+        HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+        return resp.statusCode();
     }
 }

--- a/app/src/main/java/ciserver/PipelineUpdateRequest.java
+++ b/app/src/main/java/ciserver/PipelineUpdateRequest.java
@@ -120,8 +120,8 @@ public class PipelineUpdateRequest {
      **/
     PipelineUpdateRequest(PipelineUpdateRequestDTO dto) {
         this.path = new RequestPath(dto.owner, dto.repo, dto.sha);
-        String state_str = dto.state.toString().toLowerCase();
-        this.body = new RequestBody(state_str, dto.url, dto.desc, dto.ctx);
+        String stateStr = dto.state.toString().toLowerCase();
+        this.body = new RequestBody(stateStr, dto.url, dto.desc, dto.ctx);
         this.failedOn = Optional.ofNullable(dto.failedOn);
         this.authTkn = dto.token;
     }

--- a/app/src/main/java/ciserver/PipelineUpdateRequest.java
+++ b/app/src/main/java/ciserver/PipelineUpdateRequest.java
@@ -7,6 +7,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Optional;
 import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
 
 enum CommitStatus {
     ERROR,
@@ -41,13 +42,15 @@ class RequestPath {
  **/
 class RequestBody {
     String state;
-    String target_url;
+
+    @SerializedName("target_url")
+    String targetUrl;
     String description;
     String context;
 
     RequestBody(String state, String url, String desc, String ctx) {
         this.state = state;
-        this.target_url = url;
+        this.targetUrl = url;
         this.description = desc;
         this.context = ctx;
     }
@@ -108,7 +111,7 @@ public class PipelineUpdateRequest {
     RequestPath path;
     RequestBody body;
     Optional<PipelineStage> failedOn;
-    String auth_tkn;
+    String authTkn;
 
     /**
      * Creates a new PipelineUpdateRequest object.
@@ -120,7 +123,7 @@ public class PipelineUpdateRequest {
         String state_str = dto.state.toString().toLowerCase();
         this.body = new RequestBody(state_str, dto.url, dto.desc, dto.ctx);
         this.failedOn = Optional.ofNullable(dto.failedOn);
-        this.auth_tkn = dto.token;
+        this.authTkn = dto.token;
     }
 
     /**
@@ -132,16 +135,16 @@ public class PipelineUpdateRequest {
      **/
     public HttpResponse<String> send() throws InterruptedException, IOException {
         Gson gson = new Gson();
-        String request_body = gson.toJson(this.body);
+        String requestBody = gson.toJson(this.body);
 
         // Build the actual request
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest req = HttpRequest.newBuilder()
                 .uri(URI.create("https://api.github.com/repos/" + this.path.owner + "/" + this.path.repository
                         + "/statuses/" + this.path.sha))
-                .POST(HttpRequest.BodyPublishers.ofString(request_body))
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
                 .header("Accept", "application/vnd.github+json")
-                .header("Authorization", "Bearer " + this.auth_tkn)
+                .header("Authorization", "Bearer " + this.authTkn)
                 .header("X-GitHub-Api-Version", API_VERSION)
                 .build();
 

--- a/app/src/test/java/ciserver/PipelineUpdateRequestTest.java
+++ b/app/src/test/java/ciserver/PipelineUpdateRequestTest.java
@@ -3,6 +3,7 @@ package ciserver;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
+import java.io.IOException;
 import java.net.http.HttpResponse;
 import java.util.NoSuchElementException;
 
@@ -42,16 +43,14 @@ public class PipelineUpdateRequestTest {
     }
 
     @Test
-    public void TestInvalidToken(){
+    public void TestInvalidToken() throws InterruptedException, IOException {
         PipelineUpdateRequest pr = new PipelineUpdateRequest("soffan-group-25", "ci-server", "123abc", "token",
                 CommitStatus.SUCCESS, "www.learn-more-about.this-build.com", "Test passed!", "ci", null);
 
-        try {
         HttpResponse<String> resp = pr.send();
         // API response code for "bad credentials"
-        assert(resp.statusCode() == 401);
+        assert (resp.statusCode() == 401);
         // "message": "Bad credentials"
-        assert(resp.body().contains("Bad credentials"));
-        } catch (Exception e) {}
+        assert (resp.body().contains("Bad credentials"));
     }
 }

--- a/app/src/test/java/ciserver/PipelineUpdateRequestTest.java
+++ b/app/src/test/java/ciserver/PipelineUpdateRequestTest.java
@@ -3,6 +3,7 @@ package ciserver;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
+import java.net.http.HttpResponse;
 import java.util.NoSuchElementException;
 
 public class PipelineUpdateRequestTest {
@@ -38,5 +39,19 @@ public class PipelineUpdateRequestTest {
 
         // Throw
         pr.failedOn.get();
+    }
+
+    @Test
+    public void TestInvalidToken(){
+        PipelineUpdateRequest pr = new PipelineUpdateRequest("soffan-group-25", "ci-server", "123abc", "token",
+                CommitStatus.SUCCESS, "www.learn-more-about.this-build.com", "Test passed!", "ci", null);
+
+        try {
+        HttpResponse<String> resp = pr.send();
+        // API response code for "bad credentials"
+        assert(resp.statusCode() == 401);
+        // "message": "Bad credentials"
+        assert(resp.body().contains("Bad credentials"));
+        } catch (Exception e) {}
     }
 }

--- a/app/src/test/java/ciserver/PipelineUpdateRequestTest.java
+++ b/app/src/test/java/ciserver/PipelineUpdateRequestTest.java
@@ -8,34 +8,40 @@ import java.net.http.HttpResponse;
 import java.util.NoSuchElementException;
 
 public class PipelineUpdateRequestTest {
+    private PipelineUpdateRequestDTO getPR() {
+        return new PipelineUpdateRequestDTO("soffan-group-25", "ci-server", "123abc",
+                "token", CommitStatus.SUCCESS, "www.learn-more-about.this-build.com", "Test passed!", "ci", null);
+    }
+
     @Test
     public void PipelineUpdateRequestEnum() {
-        PipelineUpdateRequest pr = new PipelineUpdateRequest("soffan-group-25", "ci-server", "123abc", "token",
-                CommitStatus.SUCCESS, "www.learn-more-about.this-build.com", "Test passed!", "ci", null);
+        var dto = getPR();
+        var pr = new PipelineUpdateRequest(dto);
         assertEquals(pr.body.state, "success");
     }
 
     @Test
     public void PipeLineUpdateRequestPathParams() {
-        PipelineUpdateRequest pr = new PipelineUpdateRequest("soffan-group-25", "ci-server", "123abc", "token",
-                CommitStatus.SUCCESS, "www.learn-more-about.this-build.com", "Test passed!", "ci", null);
+        var dto = getPR();
+        var pr = new PipelineUpdateRequest(dto);
         assertEquals(pr.path.owner, "soffan-group-25");
         assertEquals(pr.path.repository, "ci-server");
     }
 
     @Test
     public void PipelineUpdateRequestFail() {
-        PipelineUpdateRequest pr = new PipelineUpdateRequest("soffan-group-25", "ci-server", "123abc", "token",
-                CommitStatus.FAILURE, "www.learn-more-about.this-build.com", "Test passed!", "ci",
-                PipelineStage.COMPILE);
+        var dto = getPR();
+        dto.state = CommitStatus.FAILURE;
+        dto.failedOn = PipelineStage.COMPILE;
+        var pr = new PipelineUpdateRequest(dto);
         assert (!pr.failedOn.isEmpty());
         assertEquals(pr.failedOn.get(), PipelineStage.COMPILE);
     }
 
     @Test(expected = NoSuchElementException.class)
     public void PipelineUpdateRequestNoFail() {
-        PipelineUpdateRequest pr = new PipelineUpdateRequest("soffan-group-25", "ci-server", "123abc", "token",
-                CommitStatus.SUCCESS, "www.learn-more-about.this-build.com", "Test passed!", "ci", null);
+        var dto = getPR();
+        var pr = new PipelineUpdateRequest(dto);
         assert (pr.failedOn.isEmpty());
 
         // Throw
@@ -44,9 +50,8 @@ public class PipelineUpdateRequestTest {
 
     @Test
     public void TestInvalidToken() throws InterruptedException, IOException {
-        PipelineUpdateRequest pr = new PipelineUpdateRequest("soffan-group-25", "ci-server", "123abc", "token",
-                CommitStatus.SUCCESS, "www.learn-more-about.this-build.com", "Test passed!", "ci", null);
-
+        var dto = getPR();
+        var pr = new PipelineUpdateRequest(dto);
         HttpResponse<String> resp = pr.send();
         // API response code for "bad credentials"
         assert (resp.statusCode() == 401);

--- a/app/src/test/java/ciserver/PipelineUpdateRequestTest.java
+++ b/app/src/test/java/ciserver/PipelineUpdateRequestTest.java
@@ -8,30 +8,35 @@ import java.util.NoSuchElementException;
 public class PipelineUpdateRequestTest {
     @Test
     public void PipelineUpdateRequestEnum() {
-        PipelineUpdateRequest pr = new PipelineUpdateRequest("soffan-group-25", "ci-server", "123abc", CommitStatus.SUCCESS, "www.learn-more-about.this-build.com", "Test passed!", "ci", null);
+        PipelineUpdateRequest pr = new PipelineUpdateRequest("soffan-group-25", "ci-server", "123abc", "token",
+                CommitStatus.SUCCESS, "www.learn-more-about.this-build.com", "Test passed!", "ci", null);
         assertEquals(pr.body.state, "success");
     }
+
     @Test
     public void PipeLineUpdateRequestPathParams() {
-        PipelineUpdateRequest pr = new PipelineUpdateRequest("soffan-group-25", "ci-server", "123abc", CommitStatus.SUCCESS, "www.learn-more-about.this-build.com", "Test passed!", "ci", null);
+        PipelineUpdateRequest pr = new PipelineUpdateRequest("soffan-group-25", "ci-server", "123abc", "token",
+                CommitStatus.SUCCESS, "www.learn-more-about.this-build.com", "Test passed!", "ci", null);
         assertEquals(pr.path.owner, "soffan-group-25");
         assertEquals(pr.path.repository, "ci-server");
     }
 
     @Test
     public void PipelineUpdateRequestFail() {
-        PipelineUpdateRequest pr = new PipelineUpdateRequest("soffan-group-25", "ci-server", "123abc", CommitStatus.FAILURE, "www.learn-more-about.this-build.com", "Test passed!", "ci", PipelineStage.COMPILE);
-        assert(!pr.failedOn.isEmpty());
+        PipelineUpdateRequest pr = new PipelineUpdateRequest("soffan-group-25", "ci-server", "123abc", "token",
+                CommitStatus.FAILURE, "www.learn-more-about.this-build.com", "Test passed!", "ci",
+                PipelineStage.COMPILE);
+        assert (!pr.failedOn.isEmpty());
         assertEquals(pr.failedOn.get(), PipelineStage.COMPILE);
     }
 
-    @Test(expected=NoSuchElementException.class)
+    @Test(expected = NoSuchElementException.class)
     public void PipelineUpdateRequestNoFail() {
-        PipelineUpdateRequest pr = new PipelineUpdateRequest("soffan-group-25", "ci-server", "123abc", CommitStatus.SUCCESS, "www.learn-more-about.this-build.com", "Test passed!", "ci", null);
-        assert(pr.failedOn.isEmpty());
+        PipelineUpdateRequest pr = new PipelineUpdateRequest("soffan-group-25", "ci-server", "123abc", "token",
+                CommitStatus.SUCCESS, "www.learn-more-about.this-build.com", "Test passed!", "ci", null);
+        assert (pr.failedOn.isEmpty());
 
         // Throw
         pr.failedOn.get();
     }
 }
-


### PR DESCRIPTION
## Describe your changes
This adds `send` functionality to the `PipelineUpdateRequest` class, used to send the actual HTTP POST request and update the commit status. Fixes #12 (also fixes #28; these are possible duplicates).

## Checklist before requesting review

-   [x] Feature/fix PRs should add one atomic (as small as possible) feature or
        fix
-   [x] If your PR adds a feature or fix it also needs to add or modify at least
        one test
-   [x] All code in your PR needs to have been formatted
-   [x] The merge commit title should follow our commit prefix convention of
        either "feat", "fix", "chore", "doc", or "refactor"
-   [x] The merge commit body should reference at least one issue
-   [x] The code compiles and all the tests pass
