### PR TITLE
doc: add javadoc to PipelinePuller.java

### DIFF
--- a/app/src/main/java/ciserver/PipelinePuller.java
+++ b/app/src/main/java/ciserver/PipelinePuller.java
@@ -7,43 +7,47 @@ import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 
+/**
+ * This class is used early in our CI pipeline to pull the relevant ref from
+ * GitHub
+ */
 public class PipelinePuller implements StageTask {
 
-	/**
-	 * Pulls the repository and checks out the head_commit
-	 *
-	 * Inspiration from:
-	 * https://github.com/centic9/jgit-cookbook/blob/master/src/main/java/org/dstadler/jgit/unfinished/PullRemoteRepository.java
-	 * Can only pull from public repositories.
-	 *
-	 * @return the status of the pull action
-	 */
-	public PipelineStatus execute(String pipelineDir, PushEvent event) {
-		// Use the head_commit id as name for the repository directory
-		String directoryPath = String.format("%s/%s/%s", pipelineDir, event.repository.name, event.headCommit.id);
+    /**
+     * Pulls the repository and checks out the head_commit
+     *
+     * Inspiration from:
+     * https://github.com/centic9/jgit-cookbook/blob/master/src/main/java/org/dstadler/jgit/unfinished/PullRemoteRepository.java
+     * Can only pull from public repositories.
+     *
+     * @return the status of the pull action
+     */
+    public PipelineStatus execute(String pipelineDir, PushEvent event) {
+        // Use the head_commit id as name for the repository directory
+        String directoryPath = String.format("%s/%s/%s", pipelineDir, event.repository.name, event.headCommit.id);
 
-		try {
-			File directory = new File(directoryPath);
-			directory.mkdirs(); // Make the directories recursively
-			FileUtils.deleteDirectory(directory); // If there already is a repository, delete it
+        try {
+            File directory = new File(directoryPath);
+            directory.mkdirs(); // Make the directories recursively
+            FileUtils.deleteDirectory(directory); // If there already is a repository, delete it
 
-			Git.cloneRepository()
-					.setURI(event.repository.cloneUrl)
-					.setDirectory(directory)
-					.setBranch(event.ref)
-					.call() // Clone the repository
-					.checkout()
-					.setName(event.headCommit.id)
-					.call(); // Checkout the commit
+            Git.cloneRepository()
+                    .setURI(event.repository.cloneUrl)
+                    .setDirectory(directory)
+                    .setBranch(event.ref)
+                    .call() // Clone the repository
+                    .checkout()
+                    .setName(event.headCommit.id)
+                    .call(); // Checkout the commit
 
-		} catch (GitAPIException e) {
-			e.printStackTrace();
-			return PipelineStatus.Fail;
-		} catch (IOException e) {
-			e.printStackTrace();
-			return PipelineStatus.Fail;
-		}
+        } catch (GitAPIException e) {
+            e.printStackTrace();
+            return PipelineStatus.Fail;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return PipelineStatus.Fail;
+        }
 
-		return PipelineStatus.Ok;
-	}
+        return PipelineStatus.Ok;
+    }
 }

--- a/app/src/main/java/ciserver/PipelinePuller.java
+++ b/app/src/main/java/ciserver/PipelinePuller.java
@@ -20,6 +20,10 @@ public class PipelinePuller implements StageTask {
      * https://github.com/centic9/jgit-cookbook/blob/master/src/main/java/org/dstadler/jgit/unfinished/PullRemoteRepository.java
      * Can only pull from public repositories.
      *
+     * @param pipelineDir the (grand)parent directory to run the commands in
+     * @param event       specifies a subdirectory based on the repo name and head
+     *                    commit id
+     *
      * @return the status of the pull action
      */
     public PipelineStatus execute(String pipelineDir, PushEvent event) {


### PR DESCRIPTION
resolves #59 

All public classes must have JavaDoc. formatting makes this commit bigger than it should be

## Checklist before requesting review

-   [x] Feature/fix PRs should add one atomic (as small as possible) feature or
        fix
-   [x] If your PR adds a feature or fix it also needs to add or modify at least
        one test
-   [x] All code in your PR needs to have been formatted
-   [x] The merge commit title should follow our commit prefix convention of
        either "feat", "fix", "chore", "doc", or "refactor"
-   [x] The merge commit body should reference at least one issue
-   [x] The code compiles and all the tests pass
